### PR TITLE
fix compatibility with outdated clang versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,14 +15,8 @@ jobs:
 
     - uses: seanmiddleditch/gha-setup-ninja@v4
 
-    - name: Install GCC 12
-      run: |
-        sudo apt install -y gcc-12 g++-12
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 100
-
     - name: Configure CMake
-      run: cmake -B build -G Ninja
+      run: cmake -B build -G Ninja -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
 
     - name: Build
       run: cmake --build build --parallel

--- a/include/Geode/Result.hpp
+++ b/include/Geode/Result.hpp
@@ -1635,7 +1635,7 @@ namespace geode {
         /// @param operation the operation to call the Ok value with
         /// @return the Result itself
         template <class Fn>
-            requires(!std::same_as<OkType, void> && std::invocable<Fn, OkType const&>)
+            requires(!std::same_as<OkType, void> && std::invocable<Fn, std::add_lvalue_reference_t<std::add_const_t<OkType>>>)
         constexpr Result<OkType, ErrType>& inspect(Fn&& operation
         ) noexcept(noexcept(operation(std::declval<OkType const&>()))) {
             this->inspectInternal(operation);
@@ -1646,7 +1646,7 @@ namespace geode {
         /// @param operation the operation to call the Err value with
         /// @return the Result itself
         template <class Fn>
-            requires(!std::same_as<ErrType, void> && std::invocable<Fn, ErrType const&>)
+            requires(!std::same_as<ErrType, void> && std::invocable<Fn, std::add_lvalue_reference_t<std::add_const_t<ErrType>>>)
         constexpr Result<OkType, ErrType>& inspectErr(Fn&& operation
         ) noexcept(noexcept(operation(std::declval<ErrType const&>()))) {
             this->inspectInternalErr(operation);


### PR DESCRIPTION
Tested with ubuntu-22.04 runner using clang 14.0.0, no more build errors